### PR TITLE
Tried to fix the omega menu option

### DIFF
--- a/src/components/OmegaMenu.js
+++ b/src/components/OmegaMenu.js
@@ -114,6 +114,7 @@ function OmegaMenu(props) {
 			<div className="omega-menu--icon" onClick={handleToggleMenu}>
 				<BigOmegaLogo theme={state.theme} />
 			</div>
+			/* makes it mandatory for the state to be isMenuOpen and Hovered at the same time, without which it won't expand/show */
 			{state.isMenuOpen && state.isMenuHovered && (
 				<div
 					className="omega-menu--list"

--- a/src/components/OmegaMenu.js
+++ b/src/components/OmegaMenu.js
@@ -114,7 +114,7 @@ function OmegaMenu(props) {
 			<div className="omega-menu--icon" onClick={handleToggleMenu}>
 				<BigOmegaLogo theme={state.theme} />
 			</div>
-			{state.isMenuOpen && (
+			{state.isMenuOpen && state.isMenuHovered && (
 				<div
 					className="omega-menu--list"
 					style={{


### PR DESCRIPTION

# Pull Request

## Description

The big omega menu list was reported being opened by default, I've tried to fix it. I have experienced the same upon opening any problem, and it behaves similarly upon reloading the page.

## Put check marks:
## PR checklist
- [x] Added all the relevant summary for the change
- [x] Haven't Updated README (not required)
- [x] These changes are backward compatible
- [x] Have not added snapshots.
- [x] Haven't yet tested it locally, can't.
- [ ] 


- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I will be commenting my code so that it is easy to understand
- [x] My changes generate no new warnings
