### PR TITLE
Scroll set to auto, hide expand button when no companies

### DIFF
--- a/src/components/CompanyTags.js
+++ b/src/components/CompanyTags.js
@@ -65,7 +65,7 @@ function CompanyTags(props) {
 				<div
 					className="companyTagsContainer"
 					style={{
-						overflowX: state.isExpanded ? "hidden" : "scroll",
+						overflowX: state.isExpanded ? "hidden" : "auto",
 						flexWrap: state.isExpanded ? "wrap" : "nowrap"
 					}}
 				>
@@ -87,11 +87,11 @@ function CompanyTags(props) {
 							);
 						})}
 				</div>
-				<div className="companyTagsContainer--chevron" onClick={toggleExpansion}>
+                {state.companies.length > 0 && <div className="companyTagsContainer--chevron" onClick={toggleExpansion}>
 					<div style={{ transform: state.isExpanded ? "rotate(180deg)" : "" }}>
 						<ChevronDown theme={state.theme} style={{ transform: state.isExpanded ? "rotate(180deg)" : "" }} />
 					</div>
-				</div>
+				</div>}
 			</>
 
 			{state.showProblemList && !props.isOldVersion && (


### PR DESCRIPTION
# Pull Request Template

## Description
- `overflowX` on `companyTagsContainer` is changed from `scroll` to `auto`. The scroll-bar is now only shown when enough companies (hidden when 0 companies).
- Closes #76 The expand button is hidden when 0 companies.
#### Screenshot:
<img width="465" alt="image" src="https://github.com/codedecks-in/Big-Omega-Extension/assets/73903781/fefca716-5f7d-4c9b-87db-4d50dadedf0f">



## Put check marks:
## PR checklist
- [x] Added all the relevant summary for the change
- [x] Updated README (if required)
- [x] These changes are backward compatible
- [x] Added snapshots.
- [x] Tested locally before publishing the PR

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration
- Passed
- Manually tested

## Make sure all below guidelines are followed else PR will get Reject:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code so that it is easy to understand
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
